### PR TITLE
Add exit message

### DIFF
--- a/index.js
+++ b/index.js
@@ -5,6 +5,13 @@ var peerflix = require('peerflix')
 var network = require('network-address')
 var events = require('events')
 
+process.on('SIGINT', function() {
+  // we're doing some heavy lifting so it can take some time to exit... let's
+  // better output a status message so the user knows we're working on it :)
+  console.log('\nPeercast is exiting...')
+  process.exit()
+})
+
 module.exports = function(torrent, opts) {
   if (!opts) opts = {}
 


### PR DESCRIPTION
When Node.js have been working hard (steaming torrent's apparently is hard) it can sometime take a while to exit. The user might not know this and thinks it will not exit. This PR will print a nice message to the user telling him that we got the request and are working on exiting...
